### PR TITLE
Fix sorting under View By Folder Structure.

### DIFF
--- a/scripts/populate.js
+++ b/scripts/populate.js
@@ -2216,6 +2216,8 @@ class Populate {
 	sort(data) {
 		if (!ppt.libSource && !panel.multiProcess) return;
 		this.specialCharSort(data);
+		// View By Folder Structure is already sorted
+		if (ppt.folderView) return;
 		data.sort((a, b) => this.collator.compare(a.srt[2], b.srt[2]) || (a.srt[3] && !b.srt[3] ? 1 : 0));
 	}
 


### PR DESCRIPTION
As discovered in [the Georgia-Reborn Thene](https://github.com/TT-ReBORN/Georgia-ReBORN/issues/203), sorting under "View By Folder Structure" breaks if track titles have a numeric prefix. As far as I can tell, the file names are already returned by the file system in sorted order, so we can avoid doing additional sorting when folder structure view is enabled.

Fix taken from https://github.com/TT-ReBORN/Georgia-ReBORN/pull/204